### PR TITLE
Added allow api access prop in client access settings

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3378,3 +3378,5 @@ passwordCache=Enable Password Cache
 passwordCacheHelp=Whether passwords should be cached from the LDAP provider upon first use.
 passwordCacheTTL=Password Cache Period
 passwordCacheTTLHelp=How long a password should be cached before confirming with the provider again.
+allowApiAccessUI=Allow API access
+allowApiAccessHelp=Allows first party applications to access this client through POST requests in an API style rather than with redirects. This could lower your security.

--- a/js/apps/admin-ui/src/clients/add/AccessSettings.tsx
+++ b/js/apps/admin-ui/src/clients/add/AccessSettings.tsx
@@ -8,6 +8,8 @@ import { useAccess } from "../../context/access/Access";
 import { FormFields } from "../ClientDetails";
 import type { ClientSettingsProps } from "../ClientSettings";
 import { LoginSettings } from "./LoginSettings";
+import { DefaultSwitchControl } from "../../components/SwitchControl";
+import { convertAttributeNameToForm } from "../../util";
 
 export const AccessSettings = ({
   client,
@@ -29,6 +31,17 @@ export const AccessSettings = ({
       role="manage-clients"
     >
       {!client.bearerOnly && <LoginSettings protocol={protocol} />}
+      {protocol !== "saml" && (
+        <DefaultSwitchControl
+          name={convertAttributeNameToForm<FormFields>(
+            "attributes.api.access",
+          )}
+          defaultValue="false"
+          label={t("allowApiAccessUI")}
+          labelIcon={t("allowApiAccessHelp")}
+          stringify
+        />
+      )}
       {protocol !== "saml" && (
         <TextControl
           type="url"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Customization

## Description
Add 'Allow Api Access' custom field and implement the functionality in KC 26.1.4

## Related Tickets & Documents

- https://toznysecurity.atlassian.net/browse/PLAT-1728

## QA Instructions, Screenshots, Recordings

1. Create client using openid connect and saml protocol
2. Navigate to the client details settings and check that field is visible or not.
3. Enable or disable the field and test the end point during the click of save button.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: This is a frontend customization in Keycloak core so it won't have Tests.
- [ ] I need help with writing tests