### PR TITLE
Enable this tab for all open id connect clients

### DIFF
--- a/js/apps/admin-ui/src/clients/ClientDetails.tsx
+++ b/js/apps/admin-ui/src/clients/ClientDetails.tsx
@@ -555,7 +555,8 @@ export default function ClientDetails() {
                 </RoutableTabs>
               </Tab>
             )}
-            {client!.authorizationServicesEnabled &&
+            {/* Tozny Update - Make it visible for openid-connect protocol */}
+            {client.protocol === "openid-connect" &&
               !isAdminPermissionsClient &&
               (hasManageAuthorization || hasViewAuthorization) && (
                 <Tab


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Customization

## Description
Added open id protocol condition and removed the authorization flag to make this visible for all OpenID-Connect clients but SAML

## Related Tickets & Documents

- https://toznysecurity.atlassian.net/browse/PLAT-1730

## QA Instructions, Screenshots, Recordings

1. Create client using OpenID-Connect and SAML protocol
2. Navigate to the client details settings and check Authorization tab is visible or not


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: This is a frontend customization in Keycloak core so it won't have Tests.
- [ ] I need help with writing tests