### PR TITLE
Wr 595 keycloak upgrade 26.1.4 service account roles tab

### DIFF
--- a/js/apps/admin-ui/src/clients/ClientDetails.tsx
+++ b/js/apps/admin-ui/src/clients/ClientDetails.tsx
@@ -646,7 +646,8 @@ export default function ClientDetails() {
                   </RoutableTabs>
                 </Tab>
               )}
-            {client!.serviceAccountsEnabled && hasViewUsers && (
+            {/* Tozny Update - Make it visible only for OpenID-Connect clients */}
+            {client.protocol === "openid-connect" && client!.serviceAccountsEnabled && hasViewUsers && (
               <Tab
                 id="serviceAccount"
                 data-testid="serviceAccountTab"
@@ -656,6 +657,7 @@ export default function ClientDetails() {
                 <ServiceAccount client={client} />
               </Tab>
             )}
+            {/* End of Tozny Update */}
             <Tab
               id="sessions"
               data-testid="sessionsTab"

--- a/js/apps/admin-ui/src/clients/ClientDetails.tsx
+++ b/js/apps/admin-ui/src/clients/ClientDetails.tsx
@@ -647,7 +647,7 @@ export default function ClientDetails() {
                 </Tab>
               )}
             {/* Tozny Update - Make it visible only for OpenID-Connect clients */}
-            {client.protocol === "openid-connect" && client!.serviceAccountsEnabled && hasViewUsers && (
+            {client.protocol === "openid-connect" && hasViewUsers && (
               <Tab
                 id="serviceAccount"
                 data-testid="serviceAccountTab"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Customization

## Description
Added open id protocol condition to make it visible for all OpenID-Connect clients but SAML

## Related Tickets & Documents

- https://toznysecurity.atlassian.net/browse/PLAT-1731

## QA Instructions, Screenshots, Recordings

1. Create client using OpenID-Connect and SAML protocol
2. Navigate to the client details settings and check Service Account Roles tab is visible or not


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: This is a frontend customization in Keycloak core so it won't have Tests.
- [ ] I need help with writing tests