### PR TITLE
Wr 595 keycloak upgrade 26.1.4 ldap cache settings

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3374,3 +3374,7 @@ forgotPasswordCustomLink=Custom Forgot Password Link
 forgotPasswordCustomLinkHelp=(Optional) If the link begins with "http" it will be an absolute path, if not it will be appended to the host. If both the custom text and custom link are set, only the text will be displayed. To display the link insetad of text, delete any input in the text field and click "save".
 forgotPasswordCustomText=Custom Forgot Password Text
 forgotPasswordCustomTextHelp=(Optional) This text will be displayed to a user when they click "Forgot Password". If both the custom text and custom link are set, only the text will be displayed. To display the link insetad of text, delete any input in this field and click "save".
+passwordCache=Enable Password Cache
+passwordCacheHelp=Whether passwords should be cached from the LDAP provider upon first use.
+passwordCacheTTL=Password Cache Period
+passwordCacheTTLHelp=How long a password should be cached before confirming with the provider again.

--- a/js/apps/admin-ui/src/user-federation/UserFederationLdapForm.tsx
+++ b/js/apps/admin-ui/src/user-federation/UserFederationLdapForm.tsx
@@ -94,7 +94,9 @@ export const UserFederationLdapForm = ({
 export function serializeFormData(
   formData: LdapComponentRepresentation,
 ): LdapComponentRepresentation {
-  const { config } = formData;
+  // Create a deep copy to avoid mutating the original object
+  const result = JSON.parse(JSON.stringify(formData));
+  const { config } = result;
 
   if (config?.periodicChangedUsersSync !== undefined) {
     if (config.periodicChangedUsersSync === false) {
@@ -110,5 +112,20 @@ export function serializeFormData(
     delete config.periodicFullSync;
   }
 
-  return formData;
+  // Ensure password cache fields are properly formatted
+  if (config?.passwordCacheEnabled !== undefined) {
+    // Convert to string array if it's not already
+    if (!Array.isArray(config.passwordCacheEnabled)) {
+      config.passwordCacheEnabled = [config.passwordCacheEnabled.toString()];
+    }
+  }
+
+  if (config?.passwordCacheTTL !== undefined) {
+    // Convert to string array if it's not already
+    if (!Array.isArray(config.passwordCacheTTL)) {
+      config.passwordCacheTTL = [config.passwordCacheTTL.toString()];
+    }
+  }
+
+  return result;
 }

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -111,6 +111,22 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
     defaultValue: ["false"],
   });
 
+  // Watch for password cache TTL value
+  const passwordCacheTTL = useWatch({
+    control: form.control,
+    name: "config.passwordCacheTTL",
+    defaultValue: ["0"],
+  });
+
+  // Handle password cache toggle
+  const handlePasswordCacheToggle = (checked: boolean) => {
+    if (!checked) {
+      // When disabling, set TTL to 0
+      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: true });
+    }
+    form.setValue("config.passwordCacheEnabled", [checked ? "true" : "false"], { shouldDirty: true });
+  };
+
   const handleNumberInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     const value = event.target.value;
     if (value === '') {
@@ -197,8 +213,8 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
               id="kc-password-cache-switch"
               data-testid="password-cache-switch"
               isDisabled={false}
-              onChange={(_event, value) => field.onChange([`${value}`])}
-              isChecked={field.value[0] === "true"}
+              onChange={(_event, value) => handlePasswordCacheToggle(value)}
+              isChecked={field.value?.[0] === "true"}
               label={t("on")}
               labelOff={t("off")}
               aria-label={t("passwordCache")}
@@ -219,16 +235,22 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
         >
           <NumberInput
             id="kc-password-cache-ttl"
-            value={parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0")}
+            value={parseInt(passwordCacheTTL?.[0] || "0")}
             min={0}
             onPlus={() => {
-              const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
-              form.setValue("config.passwordCacheTTL", [(current + 1).toString()], { shouldDirty: true });
+              const current = parseInt(passwordCacheTTL?.[0] || "0");
+              form.setValue("config.passwordCacheTTL", [(current + 1).toString()], { 
+                shouldDirty: true,
+                shouldValidate: true 
+              });
             }}
             onMinus={() => {
-              const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
+              const current = parseInt(passwordCacheTTL?.[0] || "0");
               if (current > 0) {
-                form.setValue("config.passwordCacheTTL", [(current - 1).toString()], { shouldDirty: true });
+                form.setValue("config.passwordCacheTTL", [(current - 1).toString()], { 
+                  shouldDirty: true,
+                  shouldValidate: true 
+                });
               }
             }}
             onChange={handleNumberInputChange}

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -282,6 +282,7 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
           />
         </FormGroup>
       )}
+      {/* End of Tozny Customization */}
       {isEqual(cachePolicyType, ["EVICT_WEEKLY"]) ? (
         <SelectControl
           id="kc-eviction-day"

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -72,14 +72,36 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
     );
   }
 
-  const passwordCacheEnabled = useWatch({
+  // Watch for password cache TTL value
+  const passwordCacheTTL = useWatch({
     control: form.control,
-    name: "config.passwordCacheEnabled",
-    defaultValue: ["false"],
+    name: "config.passwordCacheTTL",
+    defaultValue: form.getValues("config.passwordCacheTTL") || ["0"],
   });
-  
-  // Ensure passwordCacheTTL has a default value
+
+  // Derive password cache enabled state from TTL value
+  const isPasswordCacheEnabled = (parseInt(passwordCacheTTL?.[0] || "0") > 0) ? ["true"] : ["false"];
+
+  // Update the form state when the component receives new props
   React.useEffect(() => {
+    if (form && form.formState.isSubmitSuccessful) {
+      // This will ensure the form values are in sync with the server
+      form.reset(form.getValues());
+    }
+  }, [form, form.formState.isSubmitSuccessful]);
+  
+  // Initialize form with default values if not set
+  React.useEffect(() => {
+    const ttlValue = form.getValues("config.passwordCacheTTL")?.[0] || "0";
+    const isEnabled = parseInt(ttlValue) > 0;
+    
+    // Set the enabled state based on TTL
+    form.setValue("config.passwordCacheEnabled", [isEnabled.toString()], { 
+      shouldDirty: false,
+      shouldValidate: true 
+    });
+    
+    // Ensure TTL has a default value
     if (!form.getValues("config.passwordCacheTTL")) {
       form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: false });
     }
@@ -93,57 +115,43 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
     }
     const numValue = parseInt(value);
     if (!isNaN(numValue) && numValue >= 0) {
-      form.setValue("config.passwordCacheTTL", [numValue.toString()], { shouldDirty: true });
+      form.setValue("config.passwordCacheTTL", [numValue.toString()], { 
+        shouldDirty: true,
+        shouldValidate: true 
+      });
+      
+      // Update the enabled state based on the new TTL value
+      form.setValue("config.passwordCacheEnabled", [(numValue > 0).toString()], {
+        shouldDirty: true,
+        shouldValidate: true
+      });
     }
   };
 
-  // Ensure passwordCacheTTL has a default value
-  React.useEffect(() => {
-    if (!form.getValues("config.passwordCacheTTL")) {
-      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: false });
-    }
-  }, [form]);
-
-  // Initialize form with default values if not set
-  React.useEffect(() => {
-    const currentValues = form.getValues();
-    if (!currentValues.config?.passwordCacheEnabled) {
-      form.setValue("config.passwordCacheEnabled", ["false"], { shouldDirty: false });
-    }
-    if (!currentValues.config?.passwordCacheTTL) {
-      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: false });
-    }
-  }, [form]);
-
-  // Watch for password cache enabled state changes
-  const isPasswordCacheEnabled = useWatch({
-    control: form.control,
-    name: "config.passwordCacheEnabled",
-    defaultValue: form.getValues("config.passwordCacheEnabled") || ["false"],
-  });
-
-  // Watch for password cache TTL value
-  const passwordCacheTTL = useWatch({
-    control: form.control,
-    name: "config.passwordCacheTTL",
-    defaultValue: form.getValues("config.passwordCacheTTL") || ["0"],
-  });
-
   // Handle password cache toggle
   const handlePasswordCacheToggle = (checked: boolean) => {
-    const newValue = checked ? "true" : "false";
-    form.setValue("config.passwordCacheEnabled", [newValue], { 
-      shouldDirty: true,
-      shouldValidate: true 
-    });
-    
-    if (!checked) {
+    if (checked) {
+      // When enabling, set a default TTL if not already set
+      const currentTTL = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
+      if (currentTTL <= 0) {
+        form.setValue("config.passwordCacheTTL", ["300"], { 
+          shouldDirty: true,
+          shouldValidate: true 
+        });
+      }
+    } else {
       // When disabling, set TTL to 0
       form.setValue("config.passwordCacheTTL", ["0"], { 
         shouldDirty: true,
         shouldValidate: true 
       });
     }
+    
+    // Always update the enabled state to match the switch
+    form.setValue("config.passwordCacheEnabled", [checked.toString()], { 
+      shouldDirty: true,
+      shouldValidate: true 
+    });
   };
 
   const handleNumberInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -233,7 +241,7 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
               data-testid="password-cache-switch"
               isDisabled={false}
               onChange={(_event, value) => handlePasswordCacheToggle(value)}
-              isChecked={field.value?.[0] === "true"}
+              isChecked={isPasswordCacheEnabled[0] === "true"}
               label={t("on")}
               labelOff={t("off")}
               aria-label={t("passwordCache")}

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -72,45 +72,46 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
     );
   }
 
+  // Update the useWatch for passwordCacheEnabled to have a proper default
+  const isPasswordCacheEnabled = useWatch({
+    control: form.control,
+    name: "config.passwordCacheEnabled",
+    defaultValue: [(form.getValues("config.passwordCacheTTL")?.[0] || "0") !== "0" ? "true" : "false"]
+  });
+
   // Watch for password cache TTL value
   const passwordCacheTTL = useWatch({
     control: form.control,
     name: "config.passwordCacheTTL",
     defaultValue: form.getValues("config.passwordCacheTTL") || ["0"],
   });
-
-  // Derive password cache enabled state from TTL value
-  const isPasswordCacheEnabled = (parseInt(passwordCacheTTL?.[0] || "0") > 0) ? ["true"] : ["false"];
-
-  // Update the form state when the component receives new props
-  React.useEffect(() => {
-    if (form && form.formState.isSubmitSuccessful) {
-      // This will ensure the form values are in sync with the server
-      form.reset(form.getValues());
-    }
-  }, [form, form.formState.isSubmitSuccessful]);
   
+  // Add this effect to initialize passwordCacheEnabled based on passwordCacheTTL
+  React.useEffect(() => {
+    const ttl = form.getValues("config.passwordCacheTTL")?.[0] || "0";
+    const isEnabled = ttl !== "0";
+    form.setValue("config.passwordCacheEnabled", [isEnabled.toString()], {
+      shouldDirty: false,
+      shouldValidate: true
+    });
+  }, [form.watch("config.passwordCacheTTL")]);
+
   // Initialize form with default values if not set
   React.useEffect(() => {
-    const ttlValue = form.getValues("config.passwordCacheTTL")?.[0] || "0";
-    const isEnabled = parseInt(ttlValue) > 0;
-    
-    // Set the enabled state based on TTL
-    form.setValue("config.passwordCacheEnabled", [isEnabled.toString()], { 
-      shouldDirty: false,
-      shouldValidate: true 
-    });
-    
-    // Ensure TTL has a default value
-    if (!form.getValues("config.passwordCacheTTL")) {
+    const currentValues = form.getValues();
+    if (!currentValues.config?.passwordCacheEnabled) {
+      form.setValue("config.passwordCacheEnabled", ["false"], { shouldDirty: false });
+    }
+    if (!currentValues.config?.passwordCacheTTL) {
       form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: false });
     }
-  }, [form]);
+  }, []);
 
   const handleNumberInputChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = (event.target as HTMLInputElement).value;
     if (value === '') {
       form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: true });
+      form.setValue("config.passwordCacheEnabled", ["false"], { shouldDirty: true });
       return;
     }
     const numValue = parseInt(value);
@@ -119,8 +120,6 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
         shouldDirty: true,
         shouldValidate: true 
       });
-      
-      // Update the enabled state based on the new TTL value
       form.setValue("config.passwordCacheEnabled", [(numValue > 0).toString()], {
         shouldDirty: true,
         shouldValidate: true
@@ -130,28 +129,23 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
 
   // Handle password cache toggle
   const handlePasswordCacheToggle = (checked: boolean) => {
-    if (checked) {
-      // When enabling, set a default TTL if not already set
-      const currentTTL = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
-      if (currentTTL <= 0) {
-        form.setValue("config.passwordCacheTTL", ["300"], { 
-          shouldDirty: true,
-          shouldValidate: true 
-        });
-      }
-    } else {
-      // When disabling, set TTL to 0
-      form.setValue("config.passwordCacheTTL", ["0"], { 
+    form.setValue("config.passwordCacheEnabled", [checked.toString()], {
+      shouldDirty: true,
+      shouldValidate: true
+    });
+    
+    if (!checked) {
+      form.setValue("config.passwordCacheTTL", ["0"], {
         shouldDirty: true,
-        shouldValidate: true 
+        shouldValidate: true
+      });
+    } else if (form.getValues("config.passwordCacheTTL")?.[0] === "0") {
+      // Only set a default TTL if it's currently 0
+      form.setValue("config.passwordCacheTTL", ["300"], {
+        shouldDirty: true,
+        shouldValidate: true
       });
     }
-    
-    // Always update the enabled state to match the switch
-    form.setValue("config.passwordCacheEnabled", [checked.toString()], { 
-      shouldDirty: true,
-      shouldValidate: true 
-    });
   };
 
   const handleNumberInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -241,7 +235,7 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
               data-testid="password-cache-switch"
               isDisabled={false}
               onChange={(_event, value) => handlePasswordCacheToggle(value)}
-              isChecked={isPasswordCacheEnabled[0] === "true"}
+              isChecked={field.value?.[0] === "true"}
               label={t("on")}
               labelOff={t("off")}
               aria-label={t("passwordCache")}

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -3,6 +3,7 @@ import {
   KeycloakSelect,
   SelectControl,
   SelectVariant,
+  Switch,
 } from "@keycloak/keycloak-ui-shared";
 import { DefaultSwitchControl } from "../../components/SwitchControl";
 import { FormGroup, NumberInput, SelectOption } from "@patternfly/react-core";
@@ -77,6 +78,13 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
     name: "config.passwordCacheEnabled",
     defaultValue: ["false"],
   });
+  
+  // Ensure passwordCacheTTL has a default value
+  React.useEffect(() => {
+    if (!form.getValues("config.passwordCacheTTL")) {
+      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: false });
+    }
+  }, [form]);
 
   const handleNumberInputChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = (event.target as HTMLInputElement).value;
@@ -89,6 +97,20 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
       form.setValue("config.passwordCacheTTL", [numValue.toString()], { shouldDirty: true });
     }
   };
+
+  // Ensure passwordCacheTTL has a default value
+  React.useEffect(() => {
+    if (!form.getValues("config.passwordCacheTTL")) {
+      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: false });
+    }
+  }, [form]);
+
+  // Watch for password cache enabled state changes
+  const isPasswordCacheEnabled = useWatch({
+    control: form.control,
+    name: "config.passwordCacheEnabled",
+    defaultValue: ["false"],
+  });
 
   const handleNumberInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -156,17 +178,36 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
         
         Note: This is a Tozny-specific optimization and not part of the standard Keycloak LDAP provider.
       */}
-      <FormGroup fieldId="kc-password-cache">
-        <DefaultSwitchControl
+      <FormGroup 
+        fieldId="kc-password-cache"
+        label={t("passwordCache")}
+        labelIcon={
+          <HelpItem
+            helpText={t("passwordCacheHelp")}
+            fieldLabelId="passwordCache"
+          />
+        }
+      >
+        <Controller
           name="config.passwordCacheEnabled"
-          label={t("passwordCache")}
-          labelIcon={t("passwordCacheHelp")}
-          aria-label={t("passwordCache")}
-          data-testid="password-cache"
+          control={form.control}
           defaultValue={["false"]}
+          render={({ field: { value, onChange } }) => (
+            <Switch
+              id="kc-password-cache-switch"
+              label={t("on")}
+              labelOff={t("off")}
+              isChecked={value?.[0] === "true"}
+              onChange={(checked: boolean) => {
+                onChange([checked ? "true" : "false"]);
+              }}
+              aria-label={t("passwordCache")}
+              data-testid="password-cache-switch"
+            />
+          )}
         />
       </FormGroup>
-      {passwordCacheEnabled?.[0] === "true" && (
+      {isPasswordCacheEnabled?.[0] === "true" && (
         <FormGroup
           label={t("passwordCacheTTL")}
           labelIcon={

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { FormAccess } from "../../components/form/FormAccess";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 import useToggle from "../../utils/useToggle";
+import React from "react";
 
 export type SettingsCacheProps = {
   form: UseFormReturn;
@@ -71,69 +72,33 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
     );
   }
 
+  const passwordCacheEnabled = useWatch({
+    control: form.control,
+    name: "config.passwordCacheEnabled",
+    defaultValue: ["false"],
+  });
+
+  const handleNumberInputChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = (event.target as HTMLInputElement).value;
+    if (value === '') {
+      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: true });
+      return;
+    }
+    const numValue = parseInt(value);
+    if (!isNaN(numValue) && numValue >= 0) {
+      form.setValue("config.passwordCacheTTL", [numValue.toString()], { shouldDirty: true });
+    }
+  };
+
+  const handleNumberInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    if (value === '') {
+      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: true });
+    }
+  };
+
   return (
     <>
-      {/* 
-        Tozny Customization: Password Cache Settings
-        
-        These fields enable caching of password verification results to reduce LDAP server load.
-        - passwordCacheEnabled: Toggles the password cache on/off
-        - passwordCacheTTL: Time-to-live in seconds for cached password verification results
-        
-        Note: This is a Tozny-specific optimization and not part of the standard Keycloak LDAP provider.
-      */}
-      <FormGroup
-        label={t("passwordCache")}
-        labelIcon={
-          <HelpItem
-            helpText={t("passwordCacheHelp")}
-            fieldLabelId="passwordCache"
-          />
-        }
-        fieldId="kc-password-cache"
-      >
-        <DefaultSwitchControl
-          name="config.passwordCacheEnabled"
-          label={t("passwordCache")}
-          labelIcon={t("passwordCacheHelp")}
-          aria-label={t("passwordCache")}
-          data-testid="password-cache"
-          defaultValue={["false"]}
-        />
-      </FormGroup>
-      <FormGroup
-        label={t("passwordCacheTTL")}
-        labelIcon={
-          <HelpItem
-            helpText={t("passwordCacheTTLHelp")}
-            fieldLabelId="passwordCacheTTL"
-          />
-        }
-        fieldId="kc-password-cache-ttl"
-      >
-        <NumberInput
-          id="kc-password-cache-ttl"
-          value={form.getValues("config.passwordCacheTTL")?.[0] || 0}
-          min={0}
-          onPlus={() => {
-            const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
-            form.setValue("config.passwordCacheTTL", [(current + 1).toString()]);
-          }}
-          onMinus={() => {
-            const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
-            if (current > 0) {
-              form.setValue("config.passwordCacheTTL", [(current - 1).toString()]);
-            }
-          }}
-          onChange={(event: React.FormEvent<HTMLInputElement>) => {
-            const target = event.target as HTMLInputElement;
-            let value = Number(target.value);
-            value = isNaN(value) ? 0 : value < 0 ? 0 : value;
-            form.setValue("config.passwordCacheTTL", [value.toString()]);
-          }}
-          aria-label={t("passwordCacheTTL")}
-        />
-      </FormGroup>
       <FormGroup
         label={t("cachePolicy")}
         labelIcon={
@@ -181,6 +146,58 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
           )}
         />
       </FormGroup>
+      
+      {/* 
+        Tozny Customization: Password Cache Settings
+        
+        These fields enable caching of password verification results to reduce LDAP server load.
+        - passwordCacheEnabled: Toggles the password cache on/off
+        - passwordCacheTTL: Time-to-live in seconds for cached password verification results
+        
+        Note: This is a Tozny-specific optimization and not part of the standard Keycloak LDAP provider.
+      */}
+      <FormGroup fieldId="kc-password-cache">
+        <DefaultSwitchControl
+          name="config.passwordCacheEnabled"
+          label={t("passwordCache")}
+          labelIcon={t("passwordCacheHelp")}
+          aria-label={t("passwordCache")}
+          data-testid="password-cache"
+          defaultValue={["false"]}
+        />
+      </FormGroup>
+      {passwordCacheEnabled?.[0] === "true" && (
+        <FormGroup
+          label={t("passwordCacheTTL")}
+          labelIcon={
+            <HelpItem
+              helpText={t("passwordCacheTTLHelp")}
+              fieldLabelId="passwordCacheTTL"
+            />
+          }
+          fieldId="kc-password-cache-ttl"
+        >
+          <NumberInput
+            id="kc-password-cache-ttl"
+            value={parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0")}
+            min={0}
+            onPlus={() => {
+              const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
+              form.setValue("config.passwordCacheTTL", [(current + 1).toString()], { shouldDirty: true });
+            }}
+            onMinus={() => {
+              const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
+              if (current > 0) {
+                form.setValue("config.passwordCacheTTL", [(current - 1).toString()], { shouldDirty: true });
+              }
+            }}
+            onChange={handleNumberInputChange}
+            onBlur={handleNumberInputBlur}
+            inputName="passwordCacheTTL"
+            inputAriaLabel={t("passwordCacheTTL")}
+          />
+        </FormGroup>
+      )}
       {isEqual(cachePolicyType, ["EVICT_WEEKLY"]) ? (
         <SelectControl
           id="kc-eviction-day"

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -95,12 +95,7 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
         <DefaultSwitchControl
           name="config.passwordCacheEnabled"
           label={t("passwordCache")}
-          labelIcon={
-            <HelpItem
-              helpText={t("passwordCacheHelp")}
-              fieldLabelId="passwordCache"
-            />
-          }
+          labelIcon={t("passwordCacheHelp")}
           aria-label={t("passwordCache")}
           data-testid="password-cache"
           defaultValue={["false"]}

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -4,7 +4,7 @@ import {
   SelectControl,
   SelectVariant,
 } from "@keycloak/keycloak-ui-shared";
-import { DefaultSwitchControl } from "../../../components/SwitchControl";
+import { DefaultSwitchControl } from "../../components/SwitchControl";
 import { FormGroup, NumberInput, SelectOption } from "@patternfly/react-core";
 import { isEqual } from "lodash-es";
 import { Controller, UseFormReturn, useWatch } from "react-hook-form";

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -3,8 +3,8 @@ import {
   KeycloakSelect,
   SelectControl,
   SelectVariant,
-  SwitchControl,
 } from "@keycloak/keycloak-ui-shared";
+import { DefaultSwitchControl } from "../../../components/SwitchControl";
 import { FormGroup, NumberInput, SelectOption } from "@patternfly/react-core";
 import { isEqual } from "lodash-es";
 import { Controller, UseFormReturn, useWatch } from "react-hook-form";
@@ -92,10 +92,15 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
         }
         fieldId="kc-password-cache"
       >
-        <SwitchControl
+        <DefaultSwitchControl
           name="config.passwordCacheEnabled"
-          label={t("on")}
-          labelOff={t("off")}
+          label={t("passwordCache")}
+          labelIcon={
+            <HelpItem
+              helpText={t("passwordCacheHelp")}
+              fieldLabelId="passwordCache"
+            />
+          }
           aria-label={t("passwordCache")}
           data-testid="password-cache"
           defaultValue={["false"]}

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -3,9 +3,8 @@ import {
   KeycloakSelect,
   SelectControl,
   SelectVariant,
-  Switch,
 } from "@keycloak/keycloak-ui-shared";
-import { DefaultSwitchControl } from "../../components/SwitchControl";
+import { Switch } from "@patternfly/react-core";
 import { FormGroup, NumberInput, SelectOption } from "@patternfly/react-core";
 import { isEqual } from "lodash-es";
 import { Controller, UseFormReturn, useWatch } from "react-hook-form";
@@ -179,7 +178,6 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
         Note: This is a Tozny-specific optimization and not part of the standard Keycloak LDAP provider.
       */}
       <FormGroup 
-        fieldId="kc-password-cache"
         label={t("passwordCache")}
         labelIcon={
           <HelpItem
@@ -187,22 +185,23 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
             fieldLabelId="passwordCache"
           />
         }
+        fieldId="kc-password-cache"
+        hasNoPaddingTop
       >
         <Controller
           name="config.passwordCacheEnabled"
-          control={form.control}
           defaultValue={["false"]}
-          render={({ field: { value, onChange } }) => (
+          control={form.control}
+          render={({ field }) => (
             <Switch
               id="kc-password-cache-switch"
+              data-testid="password-cache-switch"
+              isDisabled={false}
+              onChange={(_event, value) => field.onChange([`${value}`])}
+              isChecked={field.value[0] === "true"}
               label={t("on")}
               labelOff={t("off")}
-              isChecked={value?.[0] === "true"}
-              onChange={(checked: boolean) => {
-                onChange([checked ? "true" : "false"]);
-              }}
               aria-label={t("passwordCache")}
-              data-testid="password-cache-switch"
             />
           )}
         />

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -3,10 +3,12 @@ import {
   KeycloakSelect,
   SelectControl,
   SelectVariant,
+  SwitchControl,
 } from "@keycloak/keycloak-ui-shared";
 import { FormGroup, NumberInput, SelectOption } from "@patternfly/react-core";
 import { isEqual } from "lodash-es";
 import { Controller, UseFormReturn, useWatch } from "react-hook-form";
+import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { FormAccess } from "../../components/form/FormAccess";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
@@ -19,7 +21,7 @@ export type SettingsCacheProps = {
   unWrap?: boolean;
 };
 
-const CacheFields = ({ form }: { form: UseFormReturn }) => {
+export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => {
   const { t } = useTranslation();
 
   const [isCachePolicyOpen, toggleCachePolicy] = useToggle();
@@ -71,6 +73,67 @@ const CacheFields = ({ form }: { form: UseFormReturn }) => {
 
   return (
     <>
+      {/* 
+        Tozny Customization: Password Cache Settings
+        
+        These fields enable caching of password verification results to reduce LDAP server load.
+        - passwordCacheEnabled: Toggles the password cache on/off
+        - passwordCacheTTL: Time-to-live in seconds for cached password verification results
+        
+        Note: This is a Tozny-specific optimization and not part of the standard Keycloak LDAP provider.
+      */}
+      <FormGroup
+        label={t("passwordCache")}
+        labelIcon={
+          <HelpItem
+            helpText={t("passwordCacheHelp")}
+            fieldLabelId="passwordCache"
+          />
+        }
+        fieldId="kc-password-cache"
+      >
+        <SwitchControl
+          name="config.passwordCacheEnabled"
+          label={t("on")}
+          labelOff={t("off")}
+          aria-label={t("passwordCache")}
+          data-testid="password-cache"
+          defaultValue={["false"]}
+        />
+      </FormGroup>
+      <FormGroup
+        label={t("passwordCacheTTL")}
+        labelIcon={
+          <HelpItem
+            helpText={t("passwordCacheTTLHelp")}
+            fieldLabelId="passwordCacheTTL"
+          />
+        }
+        fieldId="kc-password-cache-ttl"
+      >
+        <NumberInput
+          id="kc-password-cache-ttl"
+          value={form.getValues("config.passwordCacheTTL")?.[0] || 0}
+          min={0}
+          onPlus={() => {
+            const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
+            form.setValue("config.passwordCacheTTL", [(current + 1).toString()]);
+          }}
+          onMinus={() => {
+            const current = parseInt(form.getValues("config.passwordCacheTTL")?.[0] || "0");
+            if (current > 0) {
+              form.setValue("config.passwordCacheTTL", [(current - 1).toString()]);
+            }
+          }}
+          onChange={(event: React.FormEvent<HTMLInputElement>) => {
+            const target = event.target as HTMLInputElement;
+            let value = Number(target.value);
+            value = isNaN(value) ? 0 : value < 0 ? 0 : value;
+            form.setValue("config.passwordCacheTTL", [value.toString()]);
+          }}
+          aria-label={t("passwordCacheTTL")}
+        />
+      </FormGroup>
       <FormGroup
         label={t("cachePolicy")}
         labelIcon={

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -104,27 +104,46 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
     }
   }, [form]);
 
+  // Initialize form with default values if not set
+  React.useEffect(() => {
+    const currentValues = form.getValues();
+    if (!currentValues.config?.passwordCacheEnabled) {
+      form.setValue("config.passwordCacheEnabled", ["false"], { shouldDirty: false });
+    }
+    if (!currentValues.config?.passwordCacheTTL) {
+      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: false });
+    }
+  }, [form]);
+
   // Watch for password cache enabled state changes
   const isPasswordCacheEnabled = useWatch({
     control: form.control,
     name: "config.passwordCacheEnabled",
-    defaultValue: ["false"],
+    defaultValue: form.getValues("config.passwordCacheEnabled") || ["false"],
   });
 
   // Watch for password cache TTL value
   const passwordCacheTTL = useWatch({
     control: form.control,
     name: "config.passwordCacheTTL",
-    defaultValue: ["0"],
+    defaultValue: form.getValues("config.passwordCacheTTL") || ["0"],
   });
 
   // Handle password cache toggle
   const handlePasswordCacheToggle = (checked: boolean) => {
+    const newValue = checked ? "true" : "false";
+    form.setValue("config.passwordCacheEnabled", [newValue], { 
+      shouldDirty: true,
+      shouldValidate: true 
+    });
+    
     if (!checked) {
       // When disabling, set TTL to 0
-      form.setValue("config.passwordCacheTTL", ["0"], { shouldDirty: true });
+      form.setValue("config.passwordCacheTTL", ["0"], { 
+        shouldDirty: true,
+        shouldValidate: true 
+      });
     }
-    form.setValue("config.passwordCacheEnabled", [checked ? "true" : "false"], { shouldDirty: true });
   };
 
   const handleNumberInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -237,6 +256,7 @@ export const CacheFields = ({ form }: { form: UseFormReturn }): ReactElement => 
             id="kc-password-cache-ttl"
             value={parseInt(passwordCacheTTL?.[0] || "0")}
             min={0}
+            isDisabled={isPasswordCacheEnabled?.[0] !== "true"}
             onPlus={() => {
               const current = parseInt(passwordCacheTTL?.[0] || "0");
               form.setValue("config.passwordCacheTTL", [(current + 1).toString()], { 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Customization

## Description
Add new custom field in ldap cache settings to enable cache and TTL period value

## Related Tickets & Documents

- https://toznysecurity.atlassian.net/browse/PLAT-1732

## QA Instructions, Screenshots, Recordings

1. Create ldap configuration in User Federation menu in KC 26
2. Switch enable or disable the cache custom field under the 'Cache Settings' section and save the changes


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: This is a frontend customization in Keycloak core so it won't have Tests.
- [ ] I need help with writing tests