### PR TITLE
Removed unlink users features in ldap config details

### DIFF
--- a/js/apps/admin-ui/src/user-federation/shared/ExtendedHeader.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/ExtendedHeader.tsx
@@ -33,13 +33,6 @@ export const ExtendedHeader = ({
     defaultValue: ["true"],
   })[0];
 
-  const [toggleUnlinkUsersDialog, UnlinkUsersDialog] = useConfirmDialog({
-    titleKey: "userFedUnlinkUsersConfirmTitle",
-    messageKey: "userFedUnlinkUsersConfirm",
-    continueButtonLabel: "unlinkUsers",
-    onConfirm: () => unlinkUsers(),
-  });
-
   const [toggleRemoveUsersDialog, RemoveUsersConfirm] = useConfirmDialog({
     titleKey: t("removeImportedUsers"),
     messageKey: t("removeImportedUsersMessage"),
@@ -109,20 +102,9 @@ export const ExtendedHeader = ({
     }
   };
 
-  const unlinkUsers = async () => {
-    try {
-      if (id) {
-        await adminClient.userStorageProvider.unlinkUsers({ id });
-      }
-      addAlert(t("unlinkUsersSuccess"), AlertVariant.success);
-    } catch (error) {
-      addError("unlinkUsersError", error);
-    }
-  };
-
   return (
     <>
-      <UnlinkUsersDialog />
+      {/* Tozny Update UnlinkUser functionality is removed like below option and related click handler<UnlinkUsersDialog /> */}
       <RemoveUsersConfirm />
       <Header
         provider={provider}
@@ -142,13 +124,6 @@ export const ExtendedHeader = ({
             isDisabled={hasImportUsers === "false"}
           >
             {t("syncAllUsers")}
-          </DropdownItem>,
-          <DropdownItem
-            key="unlink"
-            isDisabled={editMode ? editMode.includes("UNSYNCED") : false}
-            onClick={toggleUnlinkUsersDialog}
-          >
-            {t("unlinkUsers")}
           </DropdownItem>,
           <DropdownItem key="remove" onClick={toggleRemoveUsersDialog}>
             {t("removeImported")}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Customization

## Description
Removed the 'Unlink Users' option as per Tozny customization changes.

## Related Tickets & Documents

- https://toznysecurity.atlassian.net/browse/PLAT-1733

## QA Instructions, Screenshots, Recordings

1. Create ldap configuration in User Federation menu in KC 26
2. Check the 'Action' selection dropdown at the right end corner and you will not be able to see the 'Unlink Users' option


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: This is a frontend customization in Keycloak core so it won't have Tests.
- [ ] I need help with writing tests