### PR TITLE
Wr 595 keycloak upgrade 26.1.4 eidp local user

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -2125,6 +2125,7 @@ protocolMapper=Protocol...
 requiredSettings=Required Settings
 oneLevel=One Level
 userSaved=The user has been saved
+userCacheEvictionFailed=Could not evict user from cache, attribute values may be stale.
 useRefreshTokens=Use refresh tokens
 standardFlowHelp=This enables standard OpenID Connect redirect based authentication with authorization code. In terms of OpenID Connect or OAuth2 specifications, this enables support of 'Authorization Code Flow' for this client.
 clientDeleteConfirm=If you delete this client, all associated data will be removed.

--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -21,10 +21,10 @@ import {
 } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
 import { TFunction } from "i18next";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { KeyValueType } from "../components/key-value-form/key-value-convert";
@@ -38,6 +38,7 @@ import { useAccess } from "../context/access/Access";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { UserProfileProvider } from "../realm-settings/user-profile/UserProfileContext";
 import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
+import { environment } from "../environment";
 import { useParams } from "../utils/useParams";
 import { Organizations } from "./Organizations";
 import { UserAttributes } from "./UserAttributes";
@@ -66,7 +67,7 @@ import { AdminEvents } from "../events/AdminEvents";
 // Toz customized this file.
 
 export default function EditUser() {
-  const { adminClient } = useAdminClient();
+  const { adminClient, keycloak } = useAdminClient();
 
   const { t } = useTranslation();
   const { addAlert, addError } = useAlerts();
@@ -92,6 +93,21 @@ export default function EditUser() {
   const [refreshCount, setRefreshCount] = useState(0);
   const refresh = () => setRefreshCount((count) => count + 1);
   const lightweightUser = isLightweightUser(user?.id);
+
+  const location = useLocation();
+  const isOnAttributesTab = location.pathname.endsWith("/attributes");
+  const isInitialMount = useRef(true);
+
+  // When navigating TO the attributes tab, trigger a fresh load (useFetch will evict first).
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    if (isOnAttributesTab) {
+      refresh();
+    }
+  }, [isOnAttributesTab]);
   const [upConfig, setUpConfig] = useState<UserProfileConfig>();
 
   const [realmHasOrganizations, setRealmHasOrganizations] = useState(false);
@@ -122,8 +138,22 @@ export default function EditUser() {
   const eventsTab = useRoutableTab(toTab("events"));
 
   useFetch(
-    async () =>
-      Promise.all([
+    async () => {
+      if (isOnAttributesTab) {
+        try {
+          await keycloak.updateToken(5);
+          await fetch(
+            `${environment.authServerUrl}/realms/${realmName}/keycloak-usercache/evict-user/${id}`,
+            {
+              method: "PATCH",
+              headers: { Authorization: `Bearer ${keycloak.token}` },
+            },
+          );
+        } catch {
+          // Non-critical: proceed with load even if eviction fails
+        }
+      }
+      return Promise.all([
         adminClient.users.findOne({
           id: id!,
           userProfileMetadata: true,
@@ -134,7 +164,8 @@ export default function EditUser() {
         showOrganizations
           ? adminClient.organizations.find({ first: 0, max: 1 })
           : [],
-      ]),
+      ]);
+    },
     ([
       userData,
       attackDetection,

--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -150,7 +150,7 @@ export default function EditUser() {
             },
           );
         } catch {
-          // Non-critical: proceed with load even if eviction fails
+          addAlert(t("userCacheEvictionFailed"), AlertVariant.warning);
         }
       }
       return Promise.all([


### PR DESCRIPTION
When converting an EIDP user to a local user, we need to delete the created_by_eidp attribute of the external user. However, Keycloak caches the query, so the attribute added from IDMS is not immediately visible in the UI. To invalidate the cache, an “evict user” API call is made before loading the data in the Attributes tab.
